### PR TITLE
Check for Crown copyright licensing, not MOJ

### DIFF
--- a/lib/repoman/license_checker.rb
+++ b/lib/repoman/license_checker.rb
@@ -19,7 +19,8 @@ class Repoman::LicenseChecker
 
   def check_content(text)
     return fail_check("Not MIT licensed") unless /MIT License/ =~ text
-    return fail_check("Not MoJ licensed") unless /Copyright \(c\) [\d-]+ Ministry of Justice/ =~ text
+    return fail_check("Not Crown copyright licensed") unless
+      /Copyright \(c\) [\d-]+ Crown copyright \(Ministry of Justice\)/ =~ text
     passed
   end
 


### PR DESCRIPTION
Our projects, [like GDS's](https://github.com/alphagov/whitehall/blob/master/LICENCE) should actually be Copyright `Crown copyright (<department>)`, not Copyright Ministry of Justice. Given that, we should fail a repo with an incorrect copyright statement.